### PR TITLE
Allow override of identifier_in_use lambda

### DIFF
--- a/lib/noid/rails/config.rb
+++ b/lib/noid/rails/config.rb
@@ -26,7 +26,7 @@ module Noid
       # the minter will continue to cycle through ids until it finds one that
       # returns false
       def identifier_in_use
-        @identifier_in_use = lambda do |_id|
+        @identifier_in_use ||= lambda do |_id|
           false
         end
       end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Noid::Rails::Config do
   it { is_expected.to respond_to(:statefile) }
   it { is_expected.to respond_to(:namespace) }
   it { is_expected.to respond_to(:minter_class) }
+  it { is_expected.to respond_to(:identifier_in_use) }
 
   describe '#template' do
     let(:default) { '.reeddeeddk' }
@@ -39,6 +40,32 @@ RSpec.describe Noid::Rails::Config do
 
       it 'uses the different minter' do
         expect(subject.minter_class).to eq different_minter
+      end
+    end
+  end
+
+  describe '#identifier_in_use' do
+    it 'defaults to always return false' do
+      expect(subject.identifier_in_use.call('NEW_ID')).to be false
+      expect(subject.identifier_in_use.call('EXISTING_ID')).to be false
+    end
+
+    context 'when overridden' do
+      let(:override_check) do
+        lambda do |id|
+          return true if id == 'EXISTING_ID'
+          false
+        end
+      end
+
+      before { subject.identifier_in_use = override_check }
+
+      it 'returns false if id does not exist' do
+        expect(subject.identifier_in_use.call('NEW_ID')).to be false
+      end
+
+      it 'returns true if id exists' do
+        expect(subject.identifier_in_use.call('EXISTING_ID')).to be true
       end
     end
   end


### PR DESCRIPTION
Fixes #85 

Uses `||=` to allow for override of identifier_in_use lambda.  See issue for more information.