### PR TITLE
Fix deprecated/removed update_attributes! with update!

### DIFF
--- a/lib/noid/rails/minter/db.rb
+++ b/lib/noid/rails/minter/db.rb
@@ -35,7 +35,7 @@ module Noid
         # @param [::Noid::Minter] minter state containing the updates
         def serialize(inst, minter)
           # namespace and template are the same, now update the other attributes
-          inst.update_attributes!(
+          inst.update!(
             seq: minter.seq,
             counters: JSON.generate(minter.counters),
             rand: Marshal.dump(minter.instance_variable_get(:@rand))


### PR DESCRIPTION
update_attributes! has been removed as of Rails 6.1 - this patch replaces with the correct alias update!

This both allows for noid-rails to work with 6.1, but is also backwards compatible with all tested rails versions I see in CI

https://github.com/rails/rails/pull/31998