### PR TITLE
Update CI matrix to only cover supported versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,10 @@ workflows:
   ci:
     jobs:
       - bundle_and_test:
+          name: ruby2-7_rails6-1
+          ruby_version: 2.7.1
+          rails_version: 6.1.3.2
+      - bundle_and_test:
           name: ruby2-7_rails6-0
           ruby_version: 2.7.1
           rails_version: 6.0.3.1
@@ -49,11 +53,11 @@ workflows:
           name: ruby2-7_rails5-2
           ruby_version: 2.7.1
           rails_version: 5.2.4.3
-      - bundle_and_test:
-          name: ruby2-7_rails5-1
-          ruby_version: 2.7.1
-          rails_version: 5.1.7
 
+      - bundle_and_test:
+          name: ruby2-6_rails6-1
+          ruby_version: 2.6.6
+          rails_version: 6.1.3.2
       - bundle_and_test:
           name: ruby2-6_rails6-0
           ruby_version: 2.6.6
@@ -62,11 +66,11 @@ workflows:
           name: ruby2-6_rails5-2
           ruby_version: 2.6.6
           rails_version: 5.2.4.3
-      - bundle_and_test:
-          name: ruby2-6_rails5-1
-          ruby_version: 2.6.6
-          rails_version: 5.1.7
 
+      - bundle_and_test:
+          name: ruby2-5_rails6-1
+          ruby_version: 2.5.8
+          rails_version: 6.1.3.2
       - bundle_and_test:
           name: ruby2-5_rails6-0
           ruby_version: 2.5.8


### PR DESCRIPTION
* Add rails 6.1
* Remove rails 5.1
* Remove ruby 2.4
