### PR TITLE
Ensures that CircleCI executes nightly test suites

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  samvera: samvera/circleci-orb@0
+  samvera: samvera/circleci-orb@1.0
 jobs:
   bundle_and_test:
     parameters:
@@ -31,6 +31,9 @@ jobs:
             fi
             [[ -z "$(git branch --all --list master */master)" ]]
 
+      - run: 'sudo apt-get update'
+      - run: 'sudo apt-get install -y libsqlite3-dev'
+
       - samvera/bundle_for_gem:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
@@ -53,52 +56,44 @@ workflows:
     jobs:
       - bundle_and_test:
           name: ruby2-7_rails6-1
-          ruby_version: 2.7.1
+          ruby_version: 2.7.5
           rails_version: 6.1.3.2
       - bundle_and_test:
           name: ruby2-7_rails6-0
-          ruby_version: 2.7.1
+          ruby_version: 2.7.5
           rails_version: 6.0.3.1
       - bundle_and_test:
           name: ruby2-7_rails5-2
-          ruby_version: 2.7.1
+          ruby_version: 2.7.5
           rails_version: 5.2.4.3
 
       - bundle_and_test:
           name: ruby2-6_rails6-1
-          ruby_version: 2.6.6
+          ruby_version: 2.6.9
           rails_version: 6.1.3.2
       - bundle_and_test:
           name: ruby2-6_rails6-0
-          ruby_version: 2.6.6
+          ruby_version: 2.6.9
           rails_version: 6.0.3.1
       - bundle_and_test:
           name: ruby2-6_rails5-2
-          ruby_version: 2.6.6
+          ruby_version: 2.6.9
           rails_version: 5.2.4.3
 
       - bundle_and_test:
           name: ruby2-5_rails6-1
-          ruby_version: 2.5.8
+          ruby_version: 2.5.9
           rails_version: 6.1.3.2
       - bundle_and_test:
           name: ruby2-5_rails6-0
-          ruby_version: 2.5.8
+          ruby_version: 2.5.9
           rails_version: 6.0.3.1
       - bundle_and_test:
           name: ruby2-5_rails5-2
-          ruby_version: 2.5.8
+          ruby_version: 2.5.9
           rails_version: 5.2.4.3
       - bundle_and_test:
           name: ruby2-5_rails5-1
-          ruby_version: 2.5.8
+          ruby_version: 2.5.9
           rails_version: 5.1.7
 
-      - bundle_and_test:
-          name: ruby2-4_rails5-2
-          ruby_version: 2.4.10
-          rails_version: 5.2.4.3
-      - bundle_and_test:
-          name: ruby2-4_rails5-1
-          ruby_version: 2.4.10
-          rails_version: 5.1.7


### PR DESCRIPTION
Resolves #112 and addresses the following:

- Updates the CircleCI Orb to samvera/circleci-orb@1.0.1
- Tests against 2.7.5, 2.6.9, and 2.5.9
- Ensures that the libsqlite3-dev system package is installed