### PR TITLE
Prepare for release

### DIFF
--- a/lib/noid/rails/version.rb
+++ b/lib/noid/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Noid
   module Rails
-    VERSION = '3.0.3'
+    VERSION = '3.1.0'
   end
 end


### PR DESCRIPTION
Calling this 3.1.0 since support for ruby 3.0, 3.1, and 3.2 as well as rails 7 was added.  I didn't make this 4.0.0 even since only testing was dropped for older ruby/rails not excluding them in the gemspec.