### PR TITLE
Add Ruby 3.4 and Rails 8.0 to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,15 @@ workflows:
   ci:
     jobs:
       - bundle_and_test:
+          name: ruby3-4_rails8-0
+          ruby_version: 3.4.4
+          rails_version: 8.0.0
+      - bundle_and_test:
+          name: ruby3-3_rails8-0
+          ruby_version: 3.3.8
+          rails_version: 8.0.0
+          
+      - bundle_and_test:
           name: ruby3-3_rails7-2
           ruby_version: 3.3.0
           rails_version: 7.2.0
@@ -71,52 +80,3 @@ workflows:
           name: ruby3-2_rails7-1
           ruby_version: 3.2.3
           rails_version: 7.1.3
-
-      - bundle_and_test:
-          name: ruby3-3_rails7-0
-          ruby_version: 3.3.0
-          rails_version: 7.0.8
-      - bundle_and_test:
-          name: ruby3-2_rails7-0
-          ruby_version: 3.2.3
-          rails_version: 7.0.8
-
-      - bundle_and_test:
-          name: ruby3-1_rails7-1
-          ruby_version: 3.1.4
-          rails_version: 7.1.3
-      - bundle_and_test:
-          name: ruby3-1_rails7-0
-          ruby_version: 3.1.4
-          rails_version: 7.0.8
-
-      - bundle_and_test:
-          name: ruby3-0_rails7-1
-          ruby_version: 3.0.6
-          rails_version: 7.1.3
-      - bundle_and_test:
-          name: ruby3-0_rails7-0
-          ruby_version: 3.0.6
-          rails_version: 7.0.8
-      - bundle_and_test:
-          name: ruby3-0_rails6-1
-          ruby_version: 3.0.6
-          rails_version: 6.1.7.6
-      - bundle_and_test:
-          name: ruby3-0_rails6-0
-          ruby_version: 3.0.6
-          rails_version: 6.0.6.1
-
-      - bundle_and_test:
-          name: ruby2-7_rails6-1
-          ruby_version: 2.7.8
-          rails_version: 6.1.7.6
-      - bundle_and_test:
-          name: ruby2-7_rails6-0
-          ruby_version: 2.7.8
-          rails_version: 6.0.6.1
-      - bundle_and_test:
-          name: ruby2-7_rails5-2
-          ruby_version: 2.7.8
-          rails_version: 5.2.8.1
-

--- a/noid-rails.gemspec
+++ b/noid-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.metadata      = { "rubygems_mfa_required" => "true" }
 
-  spec.add_dependency 'actionpack', '>= 5.0.0', '< 8'
+  spec.add_dependency 'actionpack', '>= 5.0.0', '< 9'
   spec.add_dependency 'noid', '~> 0.9'
 
   spec.add_development_dependency 'bixby', '~> 5.0.0'


### PR DESCRIPTION
This PR also removes Ruby <= 3.1 and Rails < 7.1 from CI